### PR TITLE
Include <stdbool.h> (fixes #1)

### DIFF
--- a/src/parser/gramLatex.y
+++ b/src/parser/gramLatex.y
@@ -31,6 +31,7 @@
 #ifdef PARSELATEX_WIN32
 #include <wchar.h>
 #endif
+#include <stdbool.h>
 #include <unicode/uchar.h>
 #include <unicode/utf8.h>
 #include <Rinternals.h>


### PR DESCRIPTION
I have confirmed in a container running Ubuntu 20.04 'focal' that this fixes the issue:

```sh
* installing *source* package found in current working directory ...
* installing *source* package ‘parseLatex’ ...
** using staged installation
** libs
using C compiler: ‘gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0’
bison parser/gramLatex.y
gcc -I"/usr/share/R/include" -DNDEBUG       -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-LHi8Yy/r-base-4.4.2=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -c gramLatex.tab.c -o gramLatex.tab.o
gcc -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o parseLatex.so gramLatex.tab.o -L/usr/lib/R/lib -lR
installing to /usr/local/lib/R/site-library/00LOCK-work/00new/parseLatex/libs
** R
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (parseLatex)
```